### PR TITLE
Added themes to counteract to many theme overrides

### DIFF
--- a/game/app/pause_menu/pause_menu.tscn
+++ b/game/app/pause_menu/pause_menu.tscn
@@ -1,14 +1,8 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=5 format=2]
 
-[ext_resource path="res://shared/fonts/roboto/roboto_regular.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://app/style/theme_game_card.tres" type="Theme" id=1]
 [ext_resource path="res://app/shader/blur.shader" type="Shader" id=2]
 [ext_resource path="res://app/pause_menu/pause_menu.gd" type="Script" id=4]
-
-[sub_resource type="DynamicFont" id=1]
-font_data = ExtResource( 1 )
-
-[sub_resource type="Theme" id=2]
-default_font = SubResource( 1 )
 
 [sub_resource type="ShaderMaterial" id=3]
 shader = ExtResource( 2 )
@@ -22,10 +16,7 @@ script = ExtResource( 4 )
 [node name="Control" type="Control" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-theme = SubResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+theme = ExtResource( 1 )
 
 [node name="BlurShader" type="ColorRect" parent="Control"]
 material = SubResource( 3 )
@@ -43,38 +34,36 @@ __meta__ = {
 [node name="CC" type="CenterContainer" parent="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="VC" type="VBoxContainer" parent="Control/CC"]
-margin_left = 438.0
-margin_top = 247.0
-margin_right = 586.0
-margin_bottom = 353.0
+margin_left = 432.0
+margin_top = 226.0
+margin_right = 592.0
+margin_bottom = 374.0
+custom_constants/separation = 8
 
 [node name="Label" type="Label" parent="Control/CC/VC"]
-margin_right = 148.0
+margin_right = 160.0
 margin_bottom = 19.0
 text = "T_PAUSED"
 align = 1
 
 [node name="ButtonResume" type="Button" parent="Control/CC/VC"]
-margin_top = 23.0
-margin_right = 148.0
-margin_bottom = 48.0
+margin_top = 27.0
+margin_right = 160.0
+margin_bottom = 62.0
 text = "T_RESUME"
 
 [node name="ButtonRestart" type="Button" parent="Control/CC/VC"]
-margin_top = 52.0
-margin_right = 148.0
-margin_bottom = 77.0
+margin_top = 70.0
+margin_right = 160.0
+margin_bottom = 105.0
 text = "T_RESTART"
 
 [node name="ButtonMenu" type="Button" parent="Control/CC/VC"]
-margin_top = 81.0
-margin_right = 148.0
-margin_bottom = 106.0
+margin_top = 113.0
+margin_right = 160.0
+margin_bottom = 148.0
 text = "T_BACK_TO_MENU"
 
 [connection signal="pressed" from="Control/CC/VC/ButtonResume" to="." method="_on_ButtonResume_pressed"]

--- a/game/app/scenes/game_card.tscn
+++ b/game/app/scenes/game_card.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=2]
+[gd_scene load_steps=20 format=2]
 
 [ext_resource path="res://app/scenes/game_card.gd" type="Script" id=1]
 [ext_resource path="res://shared/fonts/roboto/roboto_regular.ttf" type="DynamicFontData" id=2]
@@ -6,6 +6,8 @@
 [ext_resource path="res://shared/fonts/roboto/roboto_black.ttf" type="DynamicFontData" id=4]
 [ext_resource path="res://app/images/cross_40.png" type="Texture" id=5]
 [ext_resource path="res://app/shader/blur.shader" type="Shader" id=6]
+[ext_resource path="res://app/style/theme_game_card.tres" type="Theme" id=7]
+[ext_resource path="res://app/style/round_icon_button_theme.tres" type="Theme" id=8]
 
 [sub_resource type="DynamicFont" id=1]
 font_data = ExtResource( 4 )
@@ -15,50 +17,6 @@ font_data = ExtResource( 2 )
 
 [sub_resource type="DynamicFont" id=2]
 font_data = ExtResource( 2 )
-
-[sub_resource type="StyleBoxFlat" id=3]
-bg_color = Color( 0.266667, 0.266667, 0.266667, 1 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
-
-[sub_resource type="StyleBoxFlat" id=4]
-bg_color = Color( 1, 1, 1, 0.12549 )
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
-border_color = Color( 1, 1, 1, 0.501961 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
-
-[sub_resource type="StyleBoxFlat" id=5]
-bg_color = Color( 0, 0, 0, 0.12549 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
-
-[sub_resource type="StyleBoxFlat" id=6]
-bg_color = Color( 0, 0, 0, 0 )
-border_width_left = 2
-border_width_top = 3
-border_width_right = 2
-border_width_bottom = 3
-border_color = Color( 0.25098, 0.627451, 1, 1 )
-border_blend = true
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
-
-[sub_resource type="StyleBoxFlat" id=7]
-bg_color = Color( 0.501961, 0.501961, 0.501961, 0.501961 )
-
-[sub_resource type="StyleBoxEmpty" id=8]
 
 [sub_resource type="StyleBoxFlat" id=12]
 bg_color = Color( 0, 0, 0, 0 )
@@ -78,13 +36,6 @@ font_data = ExtResource( 4 )
 [sub_resource type="DynamicFont" id=11]
 font_data = ExtResource( 2 )
 
-[sub_resource type="StyleBoxFlat" id=19]
-bg_color = Color( 0, 0, 0, 0 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
-
 [sub_resource type="StyleBoxFlat" id=15]
 bg_color = Color( 0.2, 0.2, 0.2, 1 )
 
@@ -99,11 +50,9 @@ bg_color = Color( 0.164706, 0.164706, 0.164706, 1 )
 margin_right = 320.0
 margin_bottom = 180.0
 rect_min_size = Vector2( 320, 180 )
+theme = ExtResource( 7 )
 color = Color( 0.2, 0.2, 0.2, 1 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="BackgroundImage" type="TextureRect" parent="."]
 visible = false
@@ -130,15 +79,12 @@ custom_constants/margin_right = 12
 custom_constants/margin_top = 12
 custom_constants/margin_left = 12
 custom_constants/margin_bottom = 12
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="VC" type="VBoxContainer" parent="MC"]
 margin_left = 12.0
 margin_top = 12.0
 margin_right = 308.0
-margin_bottom = 168.0
+margin_bottom = 175.0
 rect_min_size = Vector2( 296, 0 )
 
 [node name="HC" type="HBoxContainer" parent="MC/VC"]
@@ -265,84 +211,24 @@ __meta__ = {
 [node name="HC2" type="HBoxContainer" parent="MC/VC"]
 margin_top = 128.0
 margin_right = 296.0
-margin_bottom = 156.0
+margin_bottom = 163.0
 size_flags_vertical = 3
 alignment = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="FancyButton" type="PanelContainer" parent="MC/VC/HC2"]
-margin_left = 154.0
-margin_right = 224.0
-margin_bottom = 28.0
-custom_styles/panel = SubResource( 3 )
-
-[node name="MarginContainer" type="MarginContainer" parent="MC/VC/HC2/FancyButton"]
-margin_right = 70.0
-margin_bottom = 28.0
-custom_constants/margin_right = 12
-custom_constants/margin_left = 12
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MC/VC/HC2/FancyButton/MarginContainer"]
-margin_left = 12.0
-margin_right = 58.0
-margin_bottom = 28.0
-custom_constants/separation = 6
-
-[node name="Label" type="Label" parent="MC/VC/HC2/FancyButton/MarginContainer/HBoxContainer"]
-margin_top = 7.0
-margin_right = 46.0
-margin_bottom = 21.0
+[node name="ButtonInfo" type="Button" parent="MC/VC/HC2"]
+margin_left = 136.0
+margin_right = 212.0
+margin_bottom = 35.0
 text = "T_INFO"
 
-[node name="ButtonInfo" type="Button" parent="MC/VC/HC2/FancyButton"]
-margin_right = 70.0
-margin_bottom = 28.0
-custom_styles/hover = SubResource( 4 )
-custom_styles/pressed = SubResource( 5 )
-custom_styles/focus = SubResource( 6 )
-custom_styles/disabled = SubResource( 7 )
-custom_styles/normal = SubResource( 8 )
-
-[node name="FancyButton2" type="PanelContainer" parent="MC/VC/HC2"]
-margin_left = 228.0
+[node name="ButtonPlay" type="Button" parent="MC/VC/HC2"]
+margin_left = 216.0
 margin_right = 296.0
-margin_bottom = 28.0
-custom_styles/panel = SubResource( 3 )
-
-[node name="MarginContainer" type="MarginContainer" parent="MC/VC/HC2/FancyButton2"]
-margin_right = 68.0
-margin_bottom = 28.0
-custom_constants/margin_right = 12
-custom_constants/margin_left = 12
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MC/VC/HC2/FancyButton2/MarginContainer"]
-margin_left = 12.0
-margin_right = 56.0
-margin_bottom = 28.0
-custom_constants/separation = 6
-
-[node name="Label" type="Label" parent="MC/VC/HC2/FancyButton2/MarginContainer/HBoxContainer"]
-margin_top = 7.0
-margin_right = 44.0
-margin_bottom = 21.0
+margin_bottom = 35.0
 text = "T_PLAY"
-
-[node name="ButtonPlay" type="Button" parent="MC/VC/HC2/FancyButton2"]
-margin_right = 68.0
-margin_bottom = 28.0
-custom_styles/hover = SubResource( 4 )
-custom_styles/pressed = SubResource( 5 )
-custom_styles/focus = SubResource( 6 )
-custom_styles/disabled = SubResource( 7 )
-custom_styles/normal = SubResource( 8 )
 
 [node name="PopupDialogInfo" type="PopupDialog" parent="."]
 visible = true
@@ -474,7 +360,7 @@ __meta__ = {
 
 [node name="VC" type="VBoxContainer" parent="PopupDialogInfo/VC/PC/MC/HC"]
 margin_left = 277.0
-margin_right = 578.0
+margin_right = 576.0
 margin_bottom = 64.0
 size_flags_horizontal = 3
 alignment = 1
@@ -484,7 +370,7 @@ __meta__ = {
 
 [node name="Label" type="Label" parent="PopupDialogInfo/VC/PC/MC/HC/VC"]
 margin_top = 11.0
-margin_right = 301.0
+margin_right = 299.0
 margin_bottom = 30.0
 size_flags_horizontal = 3
 custom_fonts/font = SubResource( 11 )
@@ -496,7 +382,7 @@ __meta__ = {
 
 [node name="LabelHighscore" type="Label" parent="PopupDialogInfo/VC/PC/MC/HC/VC"]
 margin_top = 34.0
-margin_right = 301.0
+margin_right = 299.0
 margin_bottom = 53.0
 size_flags_horizontal = 3
 custom_fonts/font = SubResource( 11 )
@@ -507,41 +393,20 @@ __meta__ = {
 }
 
 [node name="VC2" type="VBoxContainer" parent="PopupDialogInfo/VC/PC/MC/HC"]
-margin_left = 578.0
+margin_left = 576.0
 margin_right = 618.0
 margin_bottom = 64.0
 
-[node name="FancyButton" type="PanelContainer" parent="PopupDialogInfo/VC/PC/MC/HC/VC2"]
-margin_right = 40.0
-margin_bottom = 40.0
-custom_styles/panel = SubResource( 19 )
-
-[node name="HBoxContainer" type="HBoxContainer" parent="PopupDialogInfo/VC/PC/MC/HC/VC2/FancyButton"]
-margin_right = 40.0
-margin_bottom = 40.0
-custom_constants/separation = 6
-
-[node name="TextureRect" type="TextureRect" parent="PopupDialogInfo/VC/PC/MC/HC/VC2/FancyButton/HBoxContainer"]
-margin_right = 40.0
-margin_bottom = 40.0
-texture = ExtResource( 5 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="ButtonClosePopup" type="Button" parent="PopupDialogInfo/VC/PC/MC/HC/VC2/FancyButton"]
-margin_right = 40.0
-margin_bottom = 40.0
-custom_styles/hover = SubResource( 4 )
-custom_styles/pressed = SubResource( 5 )
-custom_styles/focus = SubResource( 6 )
-custom_styles/disabled = SubResource( 7 )
-custom_styles/normal = SubResource( 8 )
+[node name="ButtonClosePopup" type="Button" parent="PopupDialogInfo/VC/PC/MC/HC/VC2"]
+margin_right = 42.0
+margin_bottom = 42.0
+theme = ExtResource( 8 )
+icon = ExtResource( 5 )
 
 [node name="PC2" type="PanelContainer" parent="PopupDialogInfo/VC"]
 margin_top = 96.0
 margin_right = 650.0
-margin_bottom = 340.0
+margin_bottom = 333.0
 size_flags_vertical = 3
 custom_styles/panel = SubResource( 15 )
 __meta__ = {
@@ -550,7 +415,7 @@ __meta__ = {
 
 [node name="MC" type="MarginContainer" parent="PopupDialogInfo/VC/PC2"]
 margin_right = 650.0
-margin_bottom = 244.0
+margin_bottom = 237.0
 custom_constants/margin_right = 16
 custom_constants/margin_top = 16
 custom_constants/margin_left = 16
@@ -560,12 +425,12 @@ custom_constants/margin_bottom = 16
 margin_left = 16.0
 margin_top = 16.0
 margin_right = 634.0
-margin_bottom = 228.0
+margin_bottom = 221.0
 custom_constants/separation = 16
 
 [node name="SC" type="ScrollContainer" parent="PopupDialogInfo/VC/PC2/MC/HC"]
 margin_right = 388.0
-margin_bottom = 212.0
+margin_bottom = 205.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 
@@ -592,7 +457,7 @@ __meta__ = {
 [node name="VSeparator" type="VSeparator" parent="PopupDialogInfo/VC/PC2/MC/HC"]
 margin_left = 404.0
 margin_right = 408.0
-margin_bottom = 212.0
+margin_bottom = 205.0
 custom_styles/separator = SubResource( 16 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -601,7 +466,7 @@ __meta__ = {
 [node name="VC" type="VBoxContainer" parent="PopupDialogInfo/VC/PC2/MC/HC"]
 margin_left = 424.0
 margin_right = 618.0
-margin_bottom = 212.0
+margin_bottom = 205.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="PopupDialogInfo/VC/PC2/MC/HC/VC"]
@@ -655,14 +520,14 @@ __meta__ = {
 }
 
 [node name="PC3" type="PanelContainer" parent="PopupDialogInfo/VC"]
-margin_top = 340.0
+margin_top = 333.0
 margin_right = 650.0
 margin_bottom = 400.0
 custom_styles/panel = SubResource( 17 )
 
 [node name="MC" type="MarginContainer" parent="PopupDialogInfo/VC/PC3"]
 margin_right = 650.0
-margin_bottom = 60.0
+margin_bottom = 67.0
 custom_constants/margin_right = 16
 custom_constants/margin_top = 16
 custom_constants/margin_left = 16
@@ -672,47 +537,17 @@ custom_constants/margin_bottom = 16
 margin_left = 16.0
 margin_top = 16.0
 margin_right = 634.0
-margin_bottom = 44.0
+margin_bottom = 51.0
 rect_min_size = Vector2( 0, 28 )
 alignment = 2
 
-[node name="FancyButton" type="PanelContainer" parent="PopupDialogInfo/VC/PC3/MC/HC"]
-margin_left = 550.0
+[node name="ButtonPlay" type="Button" parent="PopupDialogInfo/VC/PC3/MC/HC"]
+margin_left = 538.0
 margin_right = 618.0
-margin_bottom = 28.0
-custom_styles/panel = SubResource( 3 )
-
-[node name="MarginContainer" type="MarginContainer" parent="PopupDialogInfo/VC/PC3/MC/HC/FancyButton"]
-margin_right = 68.0
-margin_bottom = 28.0
-custom_constants/margin_right = 12
-custom_constants/margin_left = 12
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HBoxContainer" type="HBoxContainer" parent="PopupDialogInfo/VC/PC3/MC/HC/FancyButton/MarginContainer"]
-margin_left = 12.0
-margin_right = 56.0
-margin_bottom = 28.0
-custom_constants/separation = 6
-
-[node name="Label" type="Label" parent="PopupDialogInfo/VC/PC3/MC/HC/FancyButton/MarginContainer/HBoxContainer"]
-margin_top = 7.0
-margin_right = 44.0
-margin_bottom = 21.0
+margin_bottom = 35.0
 text = "T_PLAY"
 
-[node name="ButtonPlay" type="Button" parent="PopupDialogInfo/VC/PC3/MC/HC/FancyButton"]
-margin_right = 68.0
-margin_bottom = 28.0
-custom_styles/hover = SubResource( 4 )
-custom_styles/pressed = SubResource( 5 )
-custom_styles/focus = SubResource( 6 )
-custom_styles/disabled = SubResource( 7 )
-custom_styles/normal = SubResource( 8 )
-
-[connection signal="pressed" from="MC/VC/HC2/FancyButton/ButtonInfo" to="." method="_on_ButtonInfo_pressed"]
-[connection signal="pressed" from="MC/VC/HC2/FancyButton2/ButtonPlay" to="." method="_on_ButtonPlay_pressed"]
-[connection signal="pressed" from="PopupDialogInfo/VC/PC/MC/HC/VC2/FancyButton/ButtonClosePopup" to="." method="_on_ButtonClosePopup_pressed"]
-[connection signal="pressed" from="PopupDialogInfo/VC/PC3/MC/HC/FancyButton/ButtonPlay" to="." method="_on_ButtonPlay_pressed"]
+[connection signal="pressed" from="MC/VC/HC2/ButtonInfo" to="." method="_on_ButtonInfo_pressed"]
+[connection signal="pressed" from="MC/VC/HC2/ButtonPlay" to="." method="_on_ButtonPlay_pressed"]
+[connection signal="pressed" from="PopupDialogInfo/VC/PC/MC/HC/VC2/ButtonClosePopup" to="." method="_on_ButtonClosePopup_pressed"]
+[connection signal="pressed" from="PopupDialogInfo/VC/PC3/MC/HC/ButtonPlay" to="." method="_on_ButtonPlay_pressed"]

--- a/game/app/scenes/game_card.tscn
+++ b/game/app/scenes/game_card.tscn
@@ -49,10 +49,13 @@ bg_color = Color( 0.164706, 0.164706, 0.164706, 1 )
 [node name="GameCard" type="ColorRect"]
 margin_right = 320.0
 margin_bottom = 180.0
-rect_min_size = Vector2( 320, 180 )
+rect_min_size = Vector2( 320, 187 )
 theme = ExtResource( 7 )
 color = Color( 0.2, 0.2, 0.2, 1 )
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="BackgroundImage" type="TextureRect" parent="."]
 visible = false

--- a/game/app/scenes/game_card_add_yours.tscn
+++ b/game/app/scenes/game_card_add_yours.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://app/images/plus_40.png" type="Texture" id=1]
 [ext_resource path="res://shared/fonts/roboto/roboto_regular.ttf" type="DynamicFontData" id=2]
@@ -9,6 +9,16 @@ font_data = ExtResource( 2 )
 
 [sub_resource type="Theme" id=2]
 default_font = SubResource( 1 )
+
+[sub_resource type="StyleBoxEmpty" id=3]
+
+[sub_resource type="StyleBoxEmpty" id=4]
+
+[sub_resource type="StyleBoxEmpty" id=5]
+
+[sub_resource type="StyleBoxEmpty" id=6]
+
+[sub_resource type="StyleBoxEmpty" id=7]
 
 [node name="GameCardAddYours" type="ColorRect"]
 margin_right = 320.0
@@ -62,6 +72,11 @@ text = "T_ADD_YOUR_GAME"
 [node name="Button" type="Button" parent="."]
 margin_right = 320.0
 margin_bottom = 180.0
+custom_styles/hover = SubResource( 3 )
+custom_styles/pressed = SubResource( 4 )
+custom_styles/focus = SubResource( 5 )
+custom_styles/disabled = SubResource( 6 )
+custom_styles/normal = SubResource( 7 )
 flat = true
 __meta__ = {
 "_edit_use_anchors_": false

--- a/game/app/scenes/menu.tscn
+++ b/game/app/scenes/menu.tscn
@@ -30,6 +30,9 @@ anchor_bottom = 1.0
 theme = ExtResource( 3 )
 custom_constants/separation = 0
 script = ExtResource( 5 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="MenuBar" type="PanelContainer" parent="."]
 margin_right = 1024.0

--- a/game/app/scenes/menu.tscn
+++ b/game/app/scenes/menu.tscn
@@ -1,111 +1,14 @@
-[gd_scene load_steps=27 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://app/images/cogwheel_16.png" type="Texture" id=1]
 [ext_resource path="res://app/images/suffragium_badge_36.png" type="Texture" id=2]
-[ext_resource path="res://shared/fonts/roboto/roboto_regular.ttf" type="DynamicFontData" id=3]
+[ext_resource path="res://app/style/main_theme.tres" type="Theme" id=3]
 [ext_resource path="res://app/scenes/menu.gd" type="Script" id=5]
 [ext_resource path="res://shared/fonts/roboto/roboto_black.ttf" type="DynamicFontData" id=6]
 [ext_resource path="res://app/scenes/settings.gd" type="Script" id=7]
 
-[sub_resource type="DynamicFont" id=10]
-font_data = ExtResource( 3 )
-
-[sub_resource type="Theme" id=11]
-default_font = SubResource( 10 )
-
 [sub_resource type="StyleBoxFlat" id=9]
 bg_color = Color( 0.133333, 0.133333, 0.133333, 1 )
-
-[sub_resource type="StyleBoxFlat" id=4]
-bg_color = Color( 0.2, 0.2, 0.2, 1 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
-
-[sub_resource type="DynamicFont" id=12]
-font_data = ExtResource( 3 )
-
-[sub_resource type="StyleBoxFlat" id=5]
-bg_color = Color( 1, 1, 1, 0.12549 )
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
-border_color = Color( 1, 1, 1, 0.501961 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
-
-[sub_resource type="StyleBoxFlat" id=6]
-bg_color = Color( 0, 0, 0, 0.12549 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
-
-[sub_resource type="StyleBoxFlat" id=3]
-bg_color = Color( 0, 0, 0, 0 )
-border_width_left = 2
-border_width_top = 3
-border_width_right = 2
-border_width_bottom = 3
-border_color = Color( 0.25098, 0.627451, 1, 1 )
-border_blend = true
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
-
-[sub_resource type="StyleBoxFlat" id=7]
-bg_color = Color( 0.501961, 0.501961, 0.501961, 0.501961 )
-
-[sub_resource type="StyleBoxEmpty" id=8]
-
-[sub_resource type="StyleBoxFlat" id=13]
-bg_color = Color( 0.2, 0.2, 0.2, 1 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
-
-[sub_resource type="StyleBoxFlat" id=14]
-bg_color = Color( 1, 1, 1, 0.12549 )
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
-border_color = Color( 1, 1, 1, 0.501961 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
-
-[sub_resource type="StyleBoxFlat" id=15]
-bg_color = Color( 0, 0, 0, 0.12549 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
-
-[sub_resource type="StyleBoxFlat" id=16]
-bg_color = Color( 0, 0, 0, 0 )
-border_width_left = 2
-border_width_top = 3
-border_width_right = 2
-border_width_bottom = 3
-border_color = Color( 0.25098, 0.627451, 1, 1 )
-border_blend = true
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
-
-[sub_resource type="StyleBoxFlat" id=17]
-bg_color = Color( 0.501961, 0.501961, 0.501961, 0.501961 )
-
-[sub_resource type="StyleBoxEmpty" id=18]
 
 [sub_resource type="StyleBoxEmpty" id=19]
 
@@ -124,12 +27,9 @@ border_color = Color( 0.266667, 0.266667, 0.266667, 1 )
 [node name="Menu" type="VBoxContainer"]
 anchor_right = 1.0
 anchor_bottom = 1.0
-theme = SubResource( 11 )
+theme = ExtResource( 3 )
 custom_constants/separation = 0
 script = ExtResource( 5 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="MenuBar" type="PanelContainer" parent="."]
 margin_right = 1024.0
@@ -168,205 +68,38 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="FancyMenuButton4" type="PanelContainer" parent="MenuBar/MC/HC/HC"]
+[node name="ButtonGames" type="Button" parent="MenuBar/MC/HC/HC"]
 margin_left = 44.0
 margin_right = 139.0
 margin_bottom = 36.0
-rect_min_size = Vector2( 0, 36 )
-custom_styles/panel = SubResource( 4 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="MarginContainer" type="MarginContainer" parent="MenuBar/MC/HC/HC/FancyMenuButton4"]
-margin_right = 95.0
-margin_bottom = 36.0
-custom_constants/margin_right = 12
-custom_constants/margin_left = 12
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MenuBar/MC/HC/HC/FancyMenuButton4/MarginContainer"]
-margin_left = 12.0
-margin_right = 83.0
-margin_bottom = 36.0
-custom_constants/separation = 6
-
-[node name="Label" type="Label" parent="MenuBar/MC/HC/HC/FancyMenuButton4/MarginContainer/HBoxContainer"]
-margin_top = 8.0
-margin_right = 71.0
-margin_bottom = 27.0
-custom_fonts/font = SubResource( 12 )
 text = "T_GAMES"
 
-[node name="ButtonGames" type="Button" parent="MenuBar/MC/HC/HC/FancyMenuButton4"]
-margin_right = 95.0
-margin_bottom = 36.0
-custom_styles/hover = SubResource( 5 )
-custom_styles/pressed = SubResource( 6 )
-custom_styles/focus = SubResource( 3 )
-custom_styles/disabled = SubResource( 7 )
-custom_styles/normal = SubResource( 8 )
-
-[node name="FancyMenuButton" type="PanelContainer" parent="MenuBar/MC/HC/HC"]
+[node name="ButtonAbout" type="Button" parent="MenuBar/MC/HC/HC"]
 margin_left = 143.0
 margin_right = 339.0
 margin_bottom = 36.0
-rect_min_size = Vector2( 0, 36 )
-custom_styles/panel = SubResource( 4 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="MarginContainer" type="MarginContainer" parent="MenuBar/MC/HC/HC/FancyMenuButton"]
-margin_right = 196.0
-margin_bottom = 36.0
-custom_constants/margin_right = 12
-custom_constants/margin_left = 12
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MenuBar/MC/HC/HC/FancyMenuButton/MarginContainer"]
-margin_left = 12.0
-margin_right = 184.0
-margin_bottom = 36.0
-custom_constants/separation = 6
-
-[node name="Label" type="Label" parent="MenuBar/MC/HC/HC/FancyMenuButton/MarginContainer/HBoxContainer"]
-margin_top = 8.0
-margin_right = 172.0
-margin_bottom = 27.0
-custom_fonts/font = SubResource( 12 )
 text = "T_ABOUT_SUFFRAGIUM"
 
-[node name="ButtonAbout" type="Button" parent="MenuBar/MC/HC/HC/FancyMenuButton"]
-margin_right = 196.0
-margin_bottom = 36.0
-custom_styles/hover = SubResource( 5 )
-custom_styles/pressed = SubResource( 6 )
-custom_styles/focus = SubResource( 3 )
-custom_styles/disabled = SubResource( 7 )
-custom_styles/normal = SubResource( 8 )
-
-[node name="FancyMenuButton2" type="PanelContainer" parent="MenuBar/MC/HC/HC"]
+[node name="ButtonParticipate" type="Button" parent="MenuBar/MC/HC/HC"]
 margin_left = 343.0
 margin_right = 481.0
 margin_bottom = 36.0
-rect_min_size = Vector2( 0, 36 )
-custom_styles/panel = SubResource( 13 )
-
-[node name="MarginContainer" type="MarginContainer" parent="MenuBar/MC/HC/HC/FancyMenuButton2"]
-margin_right = 138.0
-margin_bottom = 36.0
-custom_constants/margin_right = 12
-custom_constants/margin_left = 12
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MenuBar/MC/HC/HC/FancyMenuButton2/MarginContainer"]
-margin_left = 12.0
-margin_right = 126.0
-margin_bottom = 36.0
-custom_constants/separation = 6
-
-[node name="Label" type="Label" parent="MenuBar/MC/HC/HC/FancyMenuButton2/MarginContainer/HBoxContainer"]
-margin_top = 8.0
-margin_right = 114.0
-margin_bottom = 27.0
 text = "T_PARTICIPATE"
 
-[node name="ButtonParticipate" type="Button" parent="MenuBar/MC/HC/HC/FancyMenuButton2"]
-margin_right = 138.0
-margin_bottom = 36.0
-custom_styles/hover = SubResource( 14 )
-custom_styles/pressed = SubResource( 15 )
-custom_styles/focus = SubResource( 16 )
-custom_styles/disabled = SubResource( 17 )
-custom_styles/normal = SubResource( 18 )
-
-[node name="FancyMenuButton3" type="PanelContainer" parent="MenuBar/MC/HC/HC"]
+[node name="ButtonReportBug" type="Button" parent="MenuBar/MC/HC/HC"]
 margin_left = 485.0
 margin_right = 641.0
 margin_bottom = 36.0
-rect_min_size = Vector2( 0, 36 )
-custom_styles/panel = SubResource( 13 )
-
-[node name="MarginContainer" type="MarginContainer" parent="MenuBar/MC/HC/HC/FancyMenuButton3"]
-margin_right = 156.0
-margin_bottom = 36.0
-custom_constants/margin_right = 12
-custom_constants/margin_left = 12
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MenuBar/MC/HC/HC/FancyMenuButton3/MarginContainer"]
-margin_left = 12.0
-margin_right = 144.0
-margin_bottom = 36.0
-custom_constants/separation = 6
-
-[node name="Label" type="Label" parent="MenuBar/MC/HC/HC/FancyMenuButton3/MarginContainer/HBoxContainer"]
-margin_top = 8.0
-margin_right = 132.0
-margin_bottom = 27.0
 text = "T_REPORT_A_BUG"
 
-[node name="ButtonReportBug" type="Button" parent="MenuBar/MC/HC/HC/FancyMenuButton3"]
-margin_right = 156.0
-margin_bottom = 36.0
-custom_styles/hover = SubResource( 14 )
-custom_styles/pressed = SubResource( 15 )
-custom_styles/focus = SubResource( 16 )
-custom_styles/disabled = SubResource( 17 )
-custom_styles/normal = SubResource( 18 )
-
-[node name="FancyMenuButton" type="PanelContainer" parent="MenuBar/MC/HC"]
+[node name="ButtonSettings" type="Button" parent="MenuBar/MC/HC"]
 margin_left = 870.0
 margin_right = 1008.0
 margin_bottom = 36.0
-rect_min_size = Vector2( 0, 36 )
-custom_styles/panel = SubResource( 13 )
-
-[node name="MarginContainer" type="MarginContainer" parent="MenuBar/MC/HC/FancyMenuButton"]
-margin_right = 138.0
-margin_bottom = 36.0
-custom_constants/margin_right = 12
-custom_constants/margin_left = 12
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MenuBar/MC/HC/FancyMenuButton/MarginContainer"]
-margin_left = 12.0
-margin_right = 126.0
-margin_bottom = 36.0
-custom_constants/separation = 6
-
-[node name="TextureRect" type="TextureRect" parent="MenuBar/MC/HC/FancyMenuButton/MarginContainer/HBoxContainer"]
-margin_right = 16.0
-margin_bottom = 36.0
-texture = ExtResource( 1 )
-stretch_mode = 4
-
-[node name="Label" type="Label" parent="MenuBar/MC/HC/FancyMenuButton/MarginContainer/HBoxContainer"]
-margin_left = 22.0
-margin_top = 8.0
-margin_right = 114.0
-margin_bottom = 27.0
+custom_constants/hseparation = 6
 text = "T_SETTINGS"
-
-[node name="ButtonSettings" type="Button" parent="MenuBar/MC/HC/FancyMenuButton"]
-margin_right = 138.0
-margin_bottom = 36.0
-custom_styles/hover = SubResource( 14 )
-custom_styles/pressed = SubResource( 15 )
-custom_styles/focus = SubResource( 16 )
-custom_styles/disabled = SubResource( 17 )
-custom_styles/normal = SubResource( 18 )
+icon = ExtResource( 1 )
+align = 0
 
 [node name="TabContainer" type="TabContainer" parent="."]
 margin_top = 52.0
@@ -385,7 +118,7 @@ anchor_bottom = 1.0
 
 [node name="MC" type="MarginContainer" parent="TabContainer/Games"]
 margin_right = 1024.0
-margin_bottom = 77.0
+margin_bottom = 83.0
 size_flags_horizontal = 3
 custom_constants/margin_right = 16
 custom_constants/margin_top = 16
@@ -396,43 +129,44 @@ custom_constants/margin_bottom = 16
 margin_left = 16.0
 margin_top = 16.0
 margin_right = 1008.0
-margin_bottom = 61.0
+margin_bottom = 67.0
 custom_constants/separation = 16
 
 [node name="HC" type="HBoxContainer" parent="TabContainer/Games/MC/VC"]
 margin_right = 992.0
-margin_bottom = 29.0
+margin_bottom = 35.0
 alignment = 2
 
 [node name="Label" type="Label" parent="TabContainer/Games/MC/VC/HC"]
-margin_right = 742.0
-margin_bottom = 29.0
+margin_top = 3.0
+margin_right = 729.0
+margin_bottom = 32.0
 size_flags_horizontal = 3
 custom_fonts/font = SubResource( 20 )
 text = "T_GAMES"
 
 [node name="Label2" type="Label" parent="TabContainer/Games/MC/VC/HC"]
-margin_left = 746.0
-margin_top = 5.0
-margin_right = 830.0
-margin_bottom = 24.0
+margin_left = 733.0
+margin_top = 8.0
+margin_right = 817.0
+margin_bottom = 27.0
 text = "T_SORTING"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="OptionButtonSorting" type="OptionButton" parent="TabContainer/Games/MC/VC/HC"]
-margin_left = 834.0
+margin_left = 821.0
 margin_right = 992.0
-margin_bottom = 29.0
+margin_bottom = 35.0
 text = "T_ALPHABETICAL"
 items = [ "T_LONGST_PLAYTIME", null, false, 0, null, "T_ALPHABETICAL", null, false, 1, null, "T_LAST_PLAYED", null, false, 2, null ]
 selected = 1
 
 [node name="HC2" type="HBoxContainer" parent="TabContainer/Games/MC/VC"]
-margin_top = 45.0
+margin_top = 51.0
 margin_right = 992.0
-margin_bottom = 45.0
+margin_bottom = 51.0
 alignment = 1
 
 [node name="GC" type="GridContainer" parent="TabContainer/Games/MC/VC/HC2"]
@@ -464,23 +198,23 @@ margin_bottom = 834.0
 custom_constants/separation = 64
 
 [node name="SectionAbout" type="VBoxContainer" parent="TabContainer/About/MC/VC"]
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 87.0
 custom_constants/separation = 16
 
 [node name="Label" type="Label" parent="TabContainer/About/MC/VC/SectionAbout"]
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 29.0
 custom_fonts/font = SubResource( 21 )
 text = "T_ABOUT_SUFFRAGIUM"
 
 [node name="VC" type="VBoxContainer" parent="TabContainer/About/MC/VC/SectionAbout"]
 margin_top = 45.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 87.0
 
 [node name="Label" type="Label" parent="TabContainer/About/MC/VC/SectionAbout/VC"]
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 19.0
 text = "T_ABOUT_SUFFRAGIUM_1"
 __meta__ = {
@@ -489,7 +223,7 @@ __meta__ = {
 
 [node name="Label2" type="Label" parent="TabContainer/About/MC/VC/SectionAbout/VC"]
 margin_top = 23.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 42.0
 text = "T_ABOUT_SUFFRAGIUM_2"
 __meta__ = {
@@ -498,33 +232,33 @@ __meta__ = {
 
 [node name="SectionParticipate" type="VBoxContainer" parent="TabContainer/About/MC/VC"]
 margin_top = 151.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 554.0
 custom_constants/separation = 16
 
 [node name="Label3" type="Label" parent="TabContainer/About/MC/VC/SectionParticipate"]
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 29.0
 custom_fonts/font = SubResource( 21 )
 text = "T_PARTICIPATE"
 
 [node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/About/MC/VC/SectionParticipate"]
 margin_top = 45.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 403.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Label" type="Label" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 19.0
 text = "T_PARTICIPATE_1"
 autowrap = true
 
 [node name="MarginContainer" type="MarginContainer" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
 margin_top = 23.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 40.0
 custom_constants/margin_top = 17
 __meta__ = {
@@ -533,35 +267,35 @@ __meta__ = {
 
 [node name="Label2" type="Label" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
 margin_top = 44.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 63.0
 text = "T_PARTICIPATE_PLEASE_NOTE"
 autowrap = true
 
 [node name="Label3" type="Label" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
 margin_top = 67.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 86.0
 text = "T_PARTICIPATE_PLEASE_NOTE_1"
 autowrap = true
 
 [node name="Label4" type="Label" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
 margin_top = 90.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 109.0
 text = "T_PARTICIPATE_PLEASE_NOTE_2"
 autowrap = true
 
 [node name="Label5" type="Label" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
 margin_top = 113.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 132.0
 text = "T_PARTICIPATE_PLEASE_NOTE_3"
 autowrap = true
 
 [node name="MarginContainer2" type="MarginContainer" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
 margin_top = 136.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 153.0
 custom_constants/margin_top = 17
 __meta__ = {
@@ -570,42 +304,42 @@ __meta__ = {
 
 [node name="Label6" type="Label" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
 margin_top = 157.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 176.0
 text = "T_PARTICIPATE_POSSIBILITIES"
 autowrap = true
 
 [node name="Label7" type="Label" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
 margin_top = 180.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 199.0
 text = "T_PARTICIPATE_POSSIBILITIES_1"
 autowrap = true
 
 [node name="Label8" type="Label" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
 margin_top = 203.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 222.0
 text = "T_PARTICIPATE_POSSIBILITIES_2"
 autowrap = true
 
 [node name="Label9" type="Label" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
 margin_top = 226.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 245.0
 text = "T_PARTICIPATE_POSSIBILITIES_3"
 autowrap = true
 
 [node name="Label10" type="Label" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
 margin_top = 249.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 268.0
 text = "T_PARTICIPATE_POSSIBILITIES_4"
 autowrap = true
 
 [node name="MarginContainer3" type="MarginContainer" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
 margin_top = 272.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 289.0
 custom_constants/margin_top = 17
 __meta__ = {
@@ -614,7 +348,7 @@ __meta__ = {
 
 [node name="Label11" type="Label" parent="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer"]
 margin_top = 293.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 312.0
 text = "T_PARTICIPATE_GUIDES"
 autowrap = true
@@ -645,54 +379,54 @@ __meta__ = {
 
 [node name="SectionReportBug" type="VBoxContainer" parent="TabContainer/About/MC/VC"]
 margin_top = 618.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 818.0
 custom_constants/separation = 16
 
 [node name="Label3" type="Label" parent="TabContainer/About/MC/VC/SectionReportBug"]
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 29.0
 custom_fonts/font = SubResource( 21 )
 text = "T_REPORT_A_BUG"
 
 [node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/About/MC/VC/SectionReportBug"]
 margin_top = 45.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 200.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Label2" type="Label" parent="TabContainer/About/MC/VC/SectionReportBug/VBoxContainer"]
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 19.0
 text = "T_PARTICIPATE_PLEASE_NOTE"
 autowrap = true
 
 [node name="Label3" type="Label" parent="TabContainer/About/MC/VC/SectionReportBug/VBoxContainer"]
 margin_top = 23.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 42.0
 text = "T_PARTICIPATE_PLEASE_NOTE_1"
 autowrap = true
 
 [node name="Label5" type="Label" parent="TabContainer/About/MC/VC/SectionReportBug/VBoxContainer"]
 margin_top = 46.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 65.0
 text = "T_PARTICIPATE_PLEASE_NOTE_2"
 autowrap = true
 
 [node name="Label6" type="Label" parent="TabContainer/About/MC/VC/SectionReportBug/VBoxContainer"]
 margin_top = 69.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 88.0
 text = "T_PARTICIPATE_PLEASE_NOTE_3"
 autowrap = true
 
 [node name="MarginContainer2" type="MarginContainer" parent="TabContainer/About/MC/VC/SectionReportBug/VBoxContainer"]
 margin_top = 92.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 109.0
 custom_constants/margin_top = 17
 __meta__ = {
@@ -701,7 +435,7 @@ __meta__ = {
 
 [node name="Label7" type="Label" parent="TabContainer/About/MC/VC/SectionReportBug/VBoxContainer"]
 margin_top = 113.0
-margin_right = 980.0
+margin_right = 982.0
 margin_bottom = 132.0
 text = "T_REPORT_A_BUG_1"
 autowrap = true
@@ -726,7 +460,7 @@ script = ExtResource( 7 )
 
 [node name="MC" type="MarginContainer" parent="TabContainer/Settings"]
 margin_right = 1024.0
-margin_bottom = 202.0
+margin_bottom = 214.0
 size_flags_horizontal = 3
 custom_constants/margin_right = 16
 custom_constants/margin_top = 16
@@ -737,7 +471,7 @@ custom_constants/margin_bottom = 16
 margin_left = 16.0
 margin_top = 16.0
 margin_right = 1008.0
-margin_bottom = 186.0
+margin_bottom = 198.0
 
 [node name="Label" type="Label" parent="TabContainer/Settings/MC/VC"]
 margin_right = 992.0
@@ -757,32 +491,32 @@ __meta__ = {
 [node name="HC" type="HBoxContainer" parent="TabContainer/Settings/MC/VC"]
 margin_top = 53.0
 margin_right = 992.0
-margin_bottom = 170.0
+margin_bottom = 182.0
 alignment = 1
 
 [node name="VC" type="VBoxContainer" parent="TabContainer/Settings/MC/VC/HC"]
 margin_left = 346.0
 margin_right = 646.0
-margin_bottom = 117.0
+margin_bottom = 129.0
 rect_min_size = Vector2( 300, 0 )
 custom_constants/separation = 8
 
 [node name="HC" type="HBoxContainer" parent="TabContainer/Settings/MC/VC/HC/VC"]
 margin_right = 300.0
-margin_bottom = 25.0
+margin_bottom = 35.0
 alignment = 2
 
 [node name="ButtonResetDefaults" type="Button" parent="TabContainer/Settings/MC/VC/HC/VC/HC"]
-margin_left = 110.0
+margin_left = 98.0
 margin_right = 300.0
-margin_bottom = 25.0
+margin_bottom = 35.0
 size_flags_horizontal = 0
 text = "T_RESET_TO_DEFAULTS"
 
 [node name="HSeparator" type="HSeparator" parent="TabContainer/Settings/MC/VC/HC/VC"]
-margin_top = 33.0
+margin_top = 43.0
 margin_right = 300.0
-margin_bottom = 49.0
+margin_bottom = 59.0
 custom_constants/separation = 16
 custom_styles/separator = SubResource( 22 )
 __meta__ = {
@@ -790,49 +524,48 @@ __meta__ = {
 }
 
 [node name="HC2" type="HBoxContainer" parent="TabContainer/Settings/MC/VC/HC/VC"]
-margin_top = 57.0
+margin_top = 67.0
 margin_right = 300.0
-margin_bottom = 82.0
+margin_bottom = 102.0
 
 [node name="Label" type="Label" parent="TabContainer/Settings/MC/VC/HC/VC/HC2"]
-margin_top = 3.0
+margin_top = 8.0
 margin_right = 148.0
-margin_bottom = 22.0
+margin_bottom = 27.0
 size_flags_horizontal = 3
 text = "T_LANGUAGE"
 
 [node name="LanguageSelection" type="OptionButton" parent="TabContainer/Settings/MC/VC/HC/VC/HC2"]
 margin_left = 152.0
 margin_right = 300.0
-margin_bottom = 25.0
+margin_bottom = 35.0
 size_flags_horizontal = 3
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="HC4" type="HBoxContainer" parent="TabContainer/Settings/MC/VC/HC/VC"]
-margin_top = 90.0
+margin_top = 110.0
 margin_right = 300.0
-margin_bottom = 117.0
+margin_bottom = 129.0
 
 [node name="Label" type="Label" parent="TabContainer/Settings/MC/VC/HC/VC/HC4"]
-margin_top = 4.0
-margin_right = 176.0
-margin_bottom = 23.0
+margin_right = 280.0
+margin_bottom = 19.0
 size_flags_horizontal = 3
 text = "T_SMOOTH_SCROLLING"
 
 [node name="CheckBoxSmoothScroll" type="CheckBox" parent="TabContainer/Settings/MC/VC/HC/VC/HC4"]
-margin_left = 180.0
+margin_left = 284.0
 margin_right = 300.0
-margin_bottom = 27.0
-size_flags_horizontal = 3
+margin_bottom = 19.0
+flat = true
 
-[connection signal="pressed" from="MenuBar/MC/HC/HC/FancyMenuButton4/ButtonGames" to="." method="_on_ButtonGames_pressed"]
-[connection signal="pressed" from="MenuBar/MC/HC/HC/FancyMenuButton/ButtonAbout" to="." method="_on_ButtonAbout_pressed"]
-[connection signal="pressed" from="MenuBar/MC/HC/HC/FancyMenuButton2/ButtonParticipate" to="." method="_on_ButtonParticipate_pressed"]
-[connection signal="pressed" from="MenuBar/MC/HC/HC/FancyMenuButton3/ButtonReportBug" to="." method="_on_ButtonReportBug_pressed"]
-[connection signal="pressed" from="MenuBar/MC/HC/FancyMenuButton/ButtonSettings" to="." method="_on_ButtonSettings_pressed"]
+[connection signal="pressed" from="MenuBar/MC/HC/HC/ButtonGames" to="." method="_on_ButtonGames_pressed"]
+[connection signal="pressed" from="MenuBar/MC/HC/HC/ButtonAbout" to="." method="_on_ButtonAbout_pressed"]
+[connection signal="pressed" from="MenuBar/MC/HC/HC/ButtonParticipate" to="." method="_on_ButtonParticipate_pressed"]
+[connection signal="pressed" from="MenuBar/MC/HC/HC/ButtonReportBug" to="." method="_on_ButtonReportBug_pressed"]
+[connection signal="pressed" from="MenuBar/MC/HC/ButtonSettings" to="." method="_on_ButtonSettings_pressed"]
 [connection signal="item_selected" from="TabContainer/Games/MC/VC/HC/OptionButtonSorting" to="." method="_on_OptionButtonSorting_item_selected"]
 [connection signal="pressed" from="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer/LinkContribute" to="." method="_on_LinkContribute_pressed"]
 [connection signal="pressed" from="TabContainer/About/MC/VC/SectionParticipate/VBoxContainer/LinkAddGame" to="." method="_on_LinkAddGame_pressed"]

--- a/game/app/style/main_theme.tres
+++ b/game/app/style/main_theme.tres
@@ -74,10 +74,10 @@ corner_radius_bottom_left = 18
 
 [sub_resource type="StyleBoxFlat" id=41]
 bg_color = Color( 0.368627, 0.368627, 0.368627, 1 )
-corner_radius_top_left = 10
-corner_radius_top_right = 10
-corner_radius_bottom_right = 10
-corner_radius_bottom_left = 10
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
 
 [sub_resource type="StyleBoxFlat" id=40]
 content_margin_left = 5.0
@@ -86,10 +86,13 @@ content_margin_top = 5.0
 content_margin_bottom = 0.0
 bg_color = Color( 0.243137, 0.243137, 0.243137, 1 )
 border_color = Color( 0, 0, 0, 1 )
-corner_radius_top_left = 10
-corner_radius_top_right = 10
-corner_radius_bottom_right = 10
-corner_radius_bottom_left = 10
+corner_radius_top_left = 14
+corner_radius_top_right = 14
+corner_radius_bottom_right = 14
+corner_radius_bottom_left = 14
+expand_margin_left = 2.0
+expand_margin_right = 2.0
+expand_margin_bottom = 5.0
 shadow_offset = Vector2( 5, 5 )
 
 [sub_resource type="StyleBoxFlat" id=35]

--- a/game/app/style/main_theme.tres
+++ b/game/app/style/main_theme.tres
@@ -1,0 +1,147 @@
+[gd_resource type="Theme" load_steps=21 format=2]
+
+[ext_resource path="res://shared/fonts/roboto/roboto_regular.ttf" type="DynamicFontData" id=1]
+
+[sub_resource type="StyleBoxFlat" id=24]
+content_margin_left = 12.0
+content_margin_right = 12.0
+bg_color = Color( 0.501961, 0.501961, 0.501961, 0.501961 )
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxFlat" id=25]
+content_margin_left = 12.0
+content_margin_right = 12.0
+bg_color = Color( 0, 0, 0, 0 )
+border_width_left = 2
+border_width_top = 3
+border_width_right = 2
+border_width_bottom = 3
+border_color = Color( 0.25098, 0.627451, 1, 1 )
+border_blend = true
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxFlat" id=26]
+content_margin_left = 12.0
+content_margin_right = 12.0
+bg_color = Color( 1, 1, 1, 0.12549 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 1, 1, 1, 0.501961 )
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxFlat" id=23]
+content_margin_left = 12.0
+content_margin_right = 12.0
+content_margin_top = 8.0
+content_margin_bottom = 8.0
+bg_color = Color( 0.2, 0.2, 0.2, 1 )
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxFlat" id=27]
+content_margin_left = 12.0
+content_margin_right = 12.0
+bg_color = Color( 0, 0, 0, 0.12549 )
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxEmpty" id=28]
+
+[sub_resource type="StyleBoxEmpty" id=29]
+
+[sub_resource type="StyleBoxEmpty" id=34]
+
+[sub_resource type="StyleBoxEmpty" id=31]
+
+[sub_resource type="StyleBoxEmpty" id=32]
+
+[sub_resource type="StyleBoxEmpty" id=33]
+
+[sub_resource type="StyleBoxFlat" id=41]
+bg_color = Color( 0.368627, 0.368627, 0.368627, 1 )
+corner_radius_top_left = 10
+corner_radius_top_right = 10
+corner_radius_bottom_right = 10
+corner_radius_bottom_left = 10
+
+[sub_resource type="StyleBoxFlat" id=40]
+content_margin_left = 5.0
+content_margin_right = 5.0
+content_margin_top = 5.0
+content_margin_bottom = 0.0
+bg_color = Color( 0.243137, 0.243137, 0.243137, 1 )
+border_color = Color( 0, 0, 0, 1 )
+corner_radius_top_left = 10
+corner_radius_top_right = 10
+corner_radius_bottom_right = 10
+corner_radius_bottom_left = 10
+shadow_offset = Vector2( 5, 5 )
+
+[sub_resource type="StyleBoxFlat" id=35]
+bg_color = Color( 0.333333, 0.333333, 0.333333, 1 )
+
+[sub_resource type="StyleBoxFlat" id=36]
+bg_color = Color( 0.25098, 0.627451, 1, 0.803922 )
+
+[sub_resource type="StyleBoxFlat" id=37]
+bg_color = Color( 0.25098, 0.627451, 1, 1 )
+
+[sub_resource type="StyleBoxFlat" id=38]
+content_margin_left = 5.0
+content_margin_right = 5.0
+bg_color = Color( 0, 0, 0, 0.117647 )
+border_color = Color( 0.258824, 0.258824, 0.258824, 1 )
+border_blend = true
+
+[sub_resource type="StyleBoxFlat" id=39]
+content_margin_left = 5.0
+content_margin_right = 5.0
+bg_color = Color( 0, 0, 0, 0.117647 )
+border_color = Color( 0.258824, 0.258824, 0.258824, 1 )
+border_blend = true
+
+[sub_resource type="DynamicFont" id=21]
+font_data = ExtResource( 1 )
+
+[resource]
+default_font = SubResource( 21 )
+Button/colors/font_color = Color( 1, 1, 1, 1 )
+Button/colors/font_color_focus = Color( 1, 1, 1, 1 )
+Button/colors/font_color_hover = Color( 1, 1, 1, 1 )
+Button/colors/font_color_pressed = Color( 1, 1, 1, 1 )
+Button/constants/hseparation = 6
+Button/styles/disabled = SubResource( 24 )
+Button/styles/focus = SubResource( 25 )
+Button/styles/hover = SubResource( 26 )
+Button/styles/normal = SubResource( 23 )
+Button/styles/pressed = SubResource( 27 )
+CheckBox/colors/font_color = Color( 1, 1, 1, 1 )
+CheckBox/styles/disabled = SubResource( 28 )
+CheckBox/styles/focus = SubResource( 29 )
+CheckBox/styles/hover = SubResource( 34 )
+CheckBox/styles/hover_pressed = SubResource( 31 )
+CheckBox/styles/normal = SubResource( 32 )
+CheckBox/styles/pressed = SubResource( 33 )
+OptionButton/constants/arrow_margin = 9
+PopupMenu/styles/hover = SubResource( 41 )
+PopupMenu/styles/panel = SubResource( 40 )
+VScrollBar/styles/grabber = SubResource( 35 )
+VScrollBar/styles/grabber_highlight = SubResource( 36 )
+VScrollBar/styles/grabber_pressed = SubResource( 37 )
+VScrollBar/styles/scroll = SubResource( 38 )
+VScrollBar/styles/scroll_focus = SubResource( 39 )

--- a/game/app/style/round_icon_button_theme.tres
+++ b/game/app/style/round_icon_button_theme.tres
@@ -9,10 +9,10 @@ border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
 border_color = Color( 0, 0, 0, 0 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
+corner_radius_top_left = 21
+corner_radius_top_right = 21
+corner_radius_bottom_right = 21
+corner_radius_bottom_left = 21
 
 [sub_resource type="StyleBoxFlat" id=25]
 bg_color = Color( 0, 0, 0, 0 )
@@ -22,22 +22,22 @@ border_width_right = 2
 border_width_bottom = 3
 border_color = Color( 0.25098, 0.627451, 1, 1 )
 border_blend = true
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
+corner_radius_top_left = 21
+corner_radius_top_right = 21
+corner_radius_bottom_right = 21
+corner_radius_bottom_left = 21
 
 [sub_resource type="StyleBoxFlat" id=26]
-bg_color = Color( 1, 1, 1, 0.12549 )
+bg_color = Color( 0.333333, 0.333333, 0.333333, 1 )
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
 border_color = Color( 1, 1, 1, 0.501961 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
+corner_radius_top_left = 21
+corner_radius_top_right = 21
+corner_radius_bottom_right = 21
+corner_radius_bottom_left = 21
 
 [sub_resource type="StyleBoxFlat" id=23]
 bg_color = Color( 0.266667, 0.266667, 0.266667, 1 )
@@ -46,10 +46,10 @@ border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
 border_color = Color( 0, 0, 0, 0 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
+corner_radius_top_left = 21
+corner_radius_top_right = 21
+corner_radius_bottom_right = 21
+corner_radius_bottom_left = 21
 
 [sub_resource type="StyleBoxFlat" id=27]
 bg_color = Color( 0, 0, 0, 0.12549 )
@@ -58,10 +58,10 @@ border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
 border_color = Color( 0, 0, 0, 0 )
-corner_radius_top_left = 18
-corner_radius_top_right = 18
-corner_radius_bottom_right = 18
-corner_radius_bottom_left = 18
+corner_radius_top_left = 21
+corner_radius_top_right = 21
+corner_radius_bottom_right = 21
+corner_radius_bottom_left = 21
 
 [sub_resource type="DynamicFont" id=21]
 font_data = ExtResource( 1 )

--- a/game/app/style/round_icon_button_theme.tres
+++ b/game/app/style/round_icon_button_theme.tres
@@ -1,0 +1,80 @@
+[gd_resource type="Theme" load_steps=8 format=2]
+
+[ext_resource path="res://shared/fonts/roboto/roboto_regular.ttf" type="DynamicFontData" id=1]
+
+[sub_resource type="StyleBoxFlat" id=24]
+bg_color = Color( 0.501961, 0.501961, 0.501961, 0.501961 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 0, 0, 0, 0 )
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxFlat" id=25]
+bg_color = Color( 0, 0, 0, 0 )
+border_width_left = 2
+border_width_top = 3
+border_width_right = 2
+border_width_bottom = 3
+border_color = Color( 0.25098, 0.627451, 1, 1 )
+border_blend = true
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxFlat" id=26]
+bg_color = Color( 1, 1, 1, 0.12549 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 1, 1, 1, 0.501961 )
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxFlat" id=23]
+bg_color = Color( 0.266667, 0.266667, 0.266667, 1 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 0, 0, 0, 0 )
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxFlat" id=27]
+bg_color = Color( 0, 0, 0, 0.12549 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 0, 0, 0, 0 )
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="DynamicFont" id=21]
+font_data = ExtResource( 1 )
+
+[resource]
+default_font = SubResource( 21 )
+Button/colors/font_color = Color( 1, 1, 1, 1 )
+Button/colors/font_color_focus = Color( 1, 1, 1, 1 )
+Button/colors/font_color_hover = Color( 1, 1, 1, 1 )
+Button/colors/font_color_pressed = Color( 1, 1, 1, 1 )
+Button/constants/hseparation = 6
+Button/styles/disabled = SubResource( 24 )
+Button/styles/focus = SubResource( 25 )
+Button/styles/hover = SubResource( 26 )
+Button/styles/normal = SubResource( 23 )
+Button/styles/pressed = SubResource( 27 )

--- a/game/app/style/theme_game_card.tres
+++ b/game/app/style/theme_game_card.tres
@@ -1,0 +1,97 @@
+[gd_resource type="Theme" load_steps=14 format=2]
+
+[ext_resource path="res://shared/fonts/roboto/roboto_regular.ttf" type="DynamicFontData" id=1]
+
+[sub_resource type="StyleBoxFlat" id=24]
+content_margin_left = 12.0
+content_margin_right = 12.0
+bg_color = Color( 0.501961, 0.501961, 0.501961, 0.501961 )
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxFlat" id=25]
+content_margin_left = 12.0
+content_margin_right = 12.0
+bg_color = Color( 0, 0, 0, 0 )
+border_width_left = 2
+border_width_top = 3
+border_width_right = 2
+border_width_bottom = 3
+border_color = Color( 0.25098, 0.627451, 1, 1 )
+border_blend = true
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxFlat" id=26]
+content_margin_left = 12.0
+content_margin_right = 12.0
+bg_color = Color( 1, 1, 1, 0.12549 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 1, 1, 1, 0.501961 )
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxFlat" id=35]
+content_margin_left = 12.0
+content_margin_right = 12.0
+content_margin_top = 8.0
+content_margin_bottom = 8.0
+bg_color = Color( 0.266667, 0.266667, 0.266667, 1 )
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxFlat" id=27]
+content_margin_left = 12.0
+content_margin_right = 12.0
+bg_color = Color( 0, 0, 0, 0.12549 )
+corner_radius_top_left = 18
+corner_radius_top_right = 18
+corner_radius_bottom_right = 18
+corner_radius_bottom_left = 18
+
+[sub_resource type="StyleBoxEmpty" id=28]
+
+[sub_resource type="StyleBoxEmpty" id=29]
+
+[sub_resource type="StyleBoxEmpty" id=34]
+
+[sub_resource type="StyleBoxEmpty" id=31]
+
+[sub_resource type="StyleBoxEmpty" id=32]
+
+[sub_resource type="StyleBoxEmpty" id=33]
+
+[sub_resource type="DynamicFont" id=21]
+font_data = ExtResource( 1 )
+
+[resource]
+default_font = SubResource( 21 )
+Button/colors/font_color = Color( 1, 1, 1, 1 )
+Button/colors/font_color_focus = Color( 1, 1, 1, 1 )
+Button/colors/font_color_hover = Color( 1, 1, 1, 1 )
+Button/colors/font_color_pressed = Color( 1, 1, 1, 1 )
+Button/constants/hseparation = 6
+Button/styles/disabled = SubResource( 24 )
+Button/styles/focus = SubResource( 25 )
+Button/styles/hover = SubResource( 26 )
+Button/styles/normal = SubResource( 35 )
+Button/styles/pressed = SubResource( 27 )
+CheckBox/colors/font_color = Color( 1, 1, 1, 1 )
+CheckBox/styles/disabled = SubResource( 28 )
+CheckBox/styles/focus = SubResource( 29 )
+CheckBox/styles/hover = SubResource( 34 )
+CheckBox/styles/hover_pressed = SubResource( 31 )
+CheckBox/styles/normal = SubResource( 32 )
+CheckBox/styles/pressed = SubResource( 33 )
+OptionButton/constants/arrow_margin = 9

--- a/game/project.godot
+++ b/game/project.godot
@@ -24,7 +24,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://games/sortit/player.gd"
 }, {
-"base": "Reference",
+"base": "MarginContainer",
 "class": "SortItRoot",
 "language": "GDScript",
 "path": "res://games/sortit/sort_it.gd"


### PR DESCRIPTION
This also adds styles to previously unstyled elements (Option Button, Scroll Bar, Pause Menu) :
![image](https://user-images.githubusercontent.com/34373974/176500157-cf9d454d-34d7-4ef3-a0da-239091d035d6.png)
![image](https://user-images.githubusercontent.com/34373974/176500214-69308420-b69f-4fba-b5bf-6864b6efb802.png)
![image](https://user-images.githubusercontent.com/34373974/176500285-07758721-2698-4794-a470-30312f3065c7.png)
![image](https://user-images.githubusercontent.com/34373974/176500376-15763dbf-4914-4c58-8108-66492681f650.png)

This will probably cause merge conflicts with the PR [ASecondGuy](https://github.com/ASecondGuy) is working on. Those should be easily resolvable though, since the themes are stored in a file and can easily be reapplied.